### PR TITLE
Fix npm packaging

### DIFF
--- a/docs/standards.md
+++ b/docs/standards.md
@@ -128,7 +128,7 @@ npm Script   | Optional | Description
 `build:lang` | ✓        | Builds language files.
 `build:test` |          | Builds the test Browserify entry point.
 `clean`      |          | Cleans up _all_ build artifacts.
-`doc`        | ✓        | Performs documentation tasks.
+`docs`       | ✓        | Performs documentation tasks.
 `lint`       |          | Lints all `.js` ES6 source file(s) using `videojs-standard`.
 `start`      |          | Starts a development server at port `9999` (or closest open port) and runs `watch`.
 `test`       |          | Runs `lint`, builds tests, and runs tests in available browsers.

--- a/src/app/package-json.js
+++ b/src/app/package-json.js
@@ -107,8 +107,13 @@ const packageJSON = (current, context) => {
       ]
     },
     'files': [
-      'dist/**/*.*',
-      'es5/**/*.js'
+      'dist/',
+      'dist-test/',
+      'es5/',
+      'scripts/',
+      'src/',
+      'test/',
+      'index.html'
     ],
     'scripts': {
       'prebuild': 'npm run clean',
@@ -214,6 +219,8 @@ const packageJSON = (current, context) => {
 
   if (context.isPrivate) {
     result.private = true;
+  } else {
+    result.files.push('CONTRIBUTING.md');
   }
 
   // Create scripts for each Karma browser.
@@ -301,6 +308,8 @@ const packageJSON = (current, context) => {
   }
 
   if (context.bower) {
+    result.files.push('bower.json');
+
     _.assign(result.scripts, {
       preversion: './scripts/npm-preversion-for-bower.sh',
       version: './scripts/npm-version-for-bower.sh',

--- a/src/app/package-json.js
+++ b/src/app/package-json.js
@@ -106,6 +106,10 @@ const packageJSON = (current, context) => {
         'scripts'
       ]
     },
+    'files': [
+      'dist/**/*.*',
+      'es5/**/*.js'
+    ],
     'scripts': {
       'prebuild': 'npm run clean',
       'build': 'npm-run-all -p build:*',
@@ -268,6 +272,8 @@ const packageJSON = (current, context) => {
 
   // Support the documentation tooling option.
   if (context.docs) {
+    result.files.push('docs');
+
     _.assign(result.scripts, {
       'docs': 'npm-run-all -p docs:*',
       'docs:api': 'documentation src/*.js -f html -o docs/api',
@@ -302,6 +308,7 @@ const packageJSON = (current, context) => {
     });
   }
 
+  result.files.sort();
   result.scripts = alphabetizeScripts(result.scripts);
   result.devDependencies = alphabetizeObject(result.devDependencies);
 

--- a/src/app/templates/_.npmignore
+++ b/src/app/templates/_.npmignore
@@ -1,35 +1,3 @@
-# OS
-Thumbs.db
-ehthumbs.db
-Desktop.ini
-.DS_Store
-._*
-
-# Editors
-*~
-*.swp
-*.tmproj
-*.tmproject
-*.sublime-*
-.idea/
-.project/
-.settings/
-.vscode/
-
-# Logs
-logs
-*.log
-npm-debug.log*
-
-# Dependency directories
-bower_components/
-node_modules/
-
-# Yeoman meta-data
-.yo-rc.json
-
-# Build-related directories
-!dist/
-!dist-test/
-!docs/
-!es5/
+# Intentionally left blank, so that npm does not ignore anything by default,
+# but relies on the package.json "files" array to explicitly define what ends
+# up in the package.

--- a/src/app/templates/_.npmignore
+++ b/src/app/templates/_.npmignore
@@ -1,3 +1,34 @@
+# OS
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+.DS_Store
+._*
+
+# Editors
+*~
+*.swp
+*.tmproj
+*.tmproject
+*.sublime-*
+.idea/
+.project/
+.settings/
+.vscode/
+
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Dependency directories
+bower_components/
+node_modules/
+
+# Yeoman meta-data
+.yo-rc.json
+
+# Build-related directories
 !dist/
 !dist-test/
 !docs/


### PR DESCRIPTION
This makes it based on the generated `.gitignore` with the difference that build directories are _not_ ignored by NPM as they are needed for projects that depend on them.