### PR TITLE
added browserify debug to generate source maps during karma test runs

### DIFF
--- a/src/app/templates/test/karma/_common.js
+++ b/src/app/templates/test/karma/_common.js
@@ -35,6 +35,7 @@ var DEFAULTS = {
   concurrency: Infinity,
 
   browserify: {
+    debug: true,
     transform: [
       'babelify',
       'browserify-shim'


### PR DESCRIPTION
I found myself adding this to nearly all of the plugins that I have been working on, because it is not very helpful for errors to point to a browserify conversion, when they should really point me to the location in the source where something is wrong. 