### PR TITLE
added babelify transform to browserify transforms in package.json

### DIFF
--- a/src/app/package-json.js
+++ b/src/app/package-json.js
@@ -165,7 +165,7 @@ const packageJSON = (current, context) => {
     'license': context.nameOf.license,
 
     'browserify': {
-      transform: ['browserify-shim']
+      transform: ['browserify-shim', 'babelify']
     },
 
     'browserify-shim': {


### PR DESCRIPTION
In order for browserify to know that the module we are trying to use requires babelify to be run (so that we can transform the es6 code to es5, and then do normal browserify things) we have to include babelify as a transform in the package.json. If we do not include this then things will not be able to require our modules with browserify because they will not be babelified at all, and browserify will complain about syntax issues when you go to try.