### PR TITLE
Move clock mock before player creation

### DIFF
--- a/src/app/templates/test/_plugin.test.js
+++ b/src/app/templates/test/_plugin.test.js
@@ -18,22 +18,22 @@ QUnit.test('the environment is sane', function(assert) {
 QUnit.module('<%= nameOf.package %>', {
 
   beforeEach() {
+
+    // Mock the environment's timers because certain things - particularly
+    // player readiness - are asynchronous in video.js 5. This MUST come
+    // before any player is created; otherwise, timers could get created
+    // with the actual timer methods!
+    this.clock = sinon.useFakeTimers();
+
     this.fixture = document.getElementById('qunit-fixture');
     this.video = document.createElement('video');
     this.fixture.appendChild(this.video);
     this.player = videojs(this.video);
-
-    // Mock the environment's timers because certain things - particularly
-    // player readiness - are asynchronous in video.js 5.
-    this.clock = sinon.useFakeTimers();
   },
 
   afterEach() {
-
-    // The clock _must_ be restored before disposing the player; otherwise,
-    // certain timeout listeners that happen inside video.js may throw errors.
-    this.clock.restore();
     this.player.dispose();
+    this.clock.restore();
   }
 });
 


### PR DESCRIPTION
This resolves a whole class of possible tricky errors in tests by ensuring that `setTimeout` et al are mocked _before_ the player (and, importantly, any timers) gets created.