### PR TITLE
Documentation Tweaks

### DIFF
--- a/docs/standards.md
+++ b/docs/standards.md
@@ -74,11 +74,11 @@ Folder/Filename            | Optional? | Generated? | Description
 `.npmignore`               |           | ✓          |
 `bower.json`               | ✓         | ?          |
 `CHANGELOG.md`             | ✓         | ✓          | May be removed if not desired.
-`CONTRIBUTING.md`          | ✓         | ?          | Not present in closed-source plugins.
+`CONTRIBUTING.md`          | ✓         | ✓          | Documents how developers can work on the plugin.
 `index.html`               | ✓         | ✓          | An example of usage of the plugin. This can be used with GitHub pages as well.
 `LICENSE`                  | ✓         | ?          | Defaults to `MIT`.
 `package.json`             |           | ✓          |
-`README.md`                |           | ✓          | Documents which version(s) of video.js the plugin supports. Explains how to build/test.
+`README.md`                |           | ✓          | Documents what the plugin does and how to use it as a general user.
 
 #### Optional?
 

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -238,6 +238,7 @@ export default yeoman.generators.Base.extend({
       'test/_index.html',
       'test/_plugin.test.js',
       '_index.html',
+      '_CONTRIBUTING.md',
       '_README.md'
     ];
 
@@ -328,7 +329,6 @@ export default yeoman.generators.Base.extend({
 
     if (!isPrivate) {
       this._filesToCopy.push('_.travis.yml');
-      this._filesToCopy.push('_CONTRIBUTING.md');
     }
 
     if (configs.lang) {

--- a/src/app/package-json.js
+++ b/src/app/package-json.js
@@ -177,14 +177,15 @@ const packageJSON = (current, context) => {
     },
 
     'files': [
-      'dist/',
+      'CONTRIBUTING.md',
       'dist-test/',
+      'dist/',
       'docs/',
       'es5/',
+      'index.html',
       'scripts/',
       'src/',
-      'test/',
-      'index.html'
+      'test/'
     ],
 
     'dependencies': _.assign({}, current.dependencies, {
@@ -222,12 +223,6 @@ const packageJSON = (current, context) => {
       'watchify': '^3.6.0'
     })
   });
-
-  if (context.isPrivate) {
-    result.private = true;
-  } else {
-    result.files.push('CONTRIBUTING.md');
-  }
 
   // Create scripts for each Karma browser.
   KARMA_BROWSERS.forEach(function(browser) {

--- a/src/app/templates/_CONTRIBUTING.md
+++ b/src/app/templates/_CONTRIBUTING.md
@@ -1,12 +1,18 @@
 # CONTRIBUTING
 
+<% if (!isPrivate) { -%>
 We welcome contributions from everyone!
 
+<% } -%>
 ## Getting Started
 
 Make sure you have NodeJS 0.10 or higher and npm installed.
 
+<% if (!isPrivate) { -%>
 1. Fork this repository and clone your fork
+<% } else { -%>
+1. Clone this repository
+<% } -%>
 1. Install dependencies: `npm install`
 1. Run a development server: `npm start`
 
@@ -22,7 +28,7 @@ Testing is a crucial part of any software project. For all but the most trivial 
 
 - In all available and supported browsers: `npm test`
 - In a specific browser: `npm run test:chrome`, `npm run test:firefox`, etc.
-- While development server is running, navigate to [`http://localhost:9999/test/`][local]
+- While development server is running (`npm start`), navigate to [`http://localhost:9999/test/`][local]
 
 
 [karma]: http://karma-runner.github.io/

--- a/src/app/templates/_CONTRIBUTING.md
+++ b/src/app/templates/_CONTRIBUTING.md
@@ -1,1 +1,30 @@
 # CONTRIBUTING
+
+We welcome contributions from everyone!
+
+## Getting Started
+
+Make sure you have NodeJS 0.10 or higher and npm installed.
+
+1. Fork this repository and clone your fork
+1. Install dependencies: `npm install`
+1. Run a development server: `npm start`
+
+### Making Changes
+
+Refer to the [video.js plugin standards][standards] for more detail on best practices and tooling for video.js plugin authorship.
+
+When you've made your changes, push your commit(s) to your fork and issue a pull request against the original repository.
+
+### Running Tests
+
+Testing is a crucial part of any software project. For all but the most trivial changes (typos, etc) test cases are expected. Tests are run in actual browsers using [Karma][karma].
+
+- In all available and supported browsers: `npm test`
+- In a specific browser: `npm run test:chrome`, `npm run test:firefox`, etc.
+- While development server is running, navigate to [`http://localhost:9999/test/`][local]
+
+
+[karma]: http://karma-runner.github.io/
+[local]: http://localhost:9999/test/
+[standards]: https://github.com/videojs/generator-videojs-plugin/docs/standards.md

--- a/src/app/templates/_README.md
+++ b/src/app/templates/_README.md
@@ -2,39 +2,76 @@
 
 <%= description %>
 
-### Table of Contents
+<% if (docs) { -%>
+## Table of Contents
 
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+<!-- START doctoc -->
+<!-- END doctoc -->
+<% } -%>
+## Installation
 
+```sh
+npm install --save <%= nameOf.package %>
+```
+<% if (bower) { -%>
 
-- [Getting Started](#getting-started)
-  - [Running Tests](#running-tests)
-  - [Tag and Release](#tag-and-release)
-- [License](#license)
+The npm installation is preferred, but Bower works, too.
 
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+```sh
+bower install  --save <%= nameOf.package %>
+```
+<% } -%>
 
-## Getting Started
+## Usage
 
-1. Clone this repository!
-1. Install dependencies: `npm install`
-1. Run a development server: `npm start`
+To include <%= nameOf.package %> on your website or web application, use any of the following methods.
 
-That's it! Refer to the [video.js plugin standards](https://github.com/videojs/generator-videojs-plugin/docs/standards.md) for more detail.
+### `<script>` Tag
 
-### Running Tests
+This is the simplest case. Get the script in whatever way you prefer and include the plugin _after_ you include [video.js][videojs], so that the `videojs` global is available.
 
-- In all available and supported browsers: `npm test`
-- In a specific browser: `npm run test:chrome`, `npm run test:firefox`, etc.
-- While development server is running, navigate to [`http://localhost:9999/test/`](http://localhost:9999/test/) (_note:_ port may vary, check console output)
+```html
+<script src="//path/to/video.min.js"></script>
+<script src="//path/to/<%= nameOf.package %>.min.js"></script>
+<script>
+  var player = videojs('my-video');
 
-### Tag and Release
+  player.<%= nameOf.function %>();
+</script>
+```
 
-1. Make sure everything is committed.
-1. `npm version *` where `*` is `major`, `minor`, `patch`, etc. [Read more about versioning.](https://github.com/videojs/generator-videojs-plugin/docs/standards.md#versioning)
-1. `npm publish`
+### Browserify
+
+When using with Browserify, install <%= nameOf.package %> via npm and `require` the plugin as you would any other module.
+
+```js
+var videojs = require('video.js');
+
+// The actual plugin function is exported by this module, but it is also
+// attached to the `Player.prototype`; so, there is no need to assign it
+// to a variable.
+require('<%= nameOf.package %>');
+
+var player = videojs('my-video');
+
+player.<%= nameOf.function %>();
+```
+
+### RequireJS/AMD
+
+When using with RequireJS (or another AMD library), get the script in whatever way you prefer and `require` the plugin as you normally would:
+
+```js
+require(['video.js', '<%= nameOf.package %>'], function(videojs) {
+  var player = videojs('my-video');
+
+  player.<%= nameOf.function %>();
+});
+```
 
 ## License
 
 <%= nameOf.license %>. Copyright (c) <%= author %>
+
+
+[videojs]: http://videojs.com/

--- a/src/test/libs.js
+++ b/src/test/libs.js
@@ -22,14 +22,14 @@ const FILES = {
     '.gitignore',
     '.npmignore',
     'CHANGELOG.md',
+    'CONTRIBUTING.md',
     'index.html',
     'README.md'
   ],
 
   oss: [
     '.travis.yml',
-    'LICENSE',
-    'CONTRIBUTING.md'
+    'LICENSE'
   ],
 
   sass: [

--- a/src/test/options.test.js
+++ b/src/test/options.test.js
@@ -1,7 +1,6 @@
 /* global before, describe, it */
 
 import * as libs from './libs';
-import _ from 'lodash';
 import {assert, test as helpers} from 'yeoman-generator';
 
 describe('videojs-plugin:app options', function() {
@@ -23,7 +22,6 @@ describe('videojs-plugin:app options', function() {
     it('produces expected package properties and file(s)', function() {
       assert.strictEqual(this.pkg.author, 'Brightcove, Inc.');
       assert.strictEqual(this.pkg.license, 'Apache-2.0');
-      assert.ok(_.isUndefined(this.pkg.private));
       assert.file(libs.fileList('oss'));
     });
   });
@@ -46,7 +44,6 @@ describe('videojs-plugin:app options', function() {
     it('produces expected package properties and file(s)', function() {
       assert.strictEqual(this.pkg.author, 'Brightcove, Inc.');
       assert.strictEqual(this.pkg.license, 'UNLICENSED');
-      assert.strictEqual(this.pkg.private, true);
       assert.noFile(libs.fileList('oss'));
     });
   });


### PR DESCRIPTION
This makes things a bit smarter with default documentation generation.

- `README.md` is now focused on consumers of the generated plugin rather than plugin developers.
- `CONTRIBUTING.md` for open-source plugins is now focused on plugin developers.