### PR TITLE
Address author prompt from object

### DIFF
--- a/fixtures/author/package.json
+++ b/fixtures/author/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "videojs-author-fixture",
+  "description": "This is a fixture to test the handling of an author object.",
+  "author": {
+    "name": "John Doe",
+    "email": "john@doe.com"
+  },
+  "license": "MIT",
+  "version": "1.0.0"
+}

--- a/package.json
+++ b/package.json
@@ -48,13 +48,14 @@
     "npm-run-all": "~1.2.0",
     "tap": "^2.3.1",
     "tap-parser": "^1.2.2",
-    "tsml": "^1.0.1",
+    "tsmlj": "^1.0.0",
     "yeoman-generator": "^0.20.0",
     "yosay": "^1.0.2"
   },
   "devDependencies": {
     "babel": "^5.8.34",
     "doctoc": "^0.15.0",
+    "fs-extra": "^0.26.4",
     "mocha": "^2.3.4",
     "videojs-standard": "^4.0.0"
   }

--- a/src/test/app.test.js
+++ b/src/test/app.test.js
@@ -1,6 +1,8 @@
 /* global before, describe, it */
 
 import _ from 'lodash';
+import fs from 'fs-extra';
+import path from 'path';
 import {assert, test as helpers} from 'yeoman-generator';
 
 import * as libs from './libs';
@@ -142,6 +144,41 @@ describe('videojs-plugin:app', function() {
     });
   });
 
+  describe('existing package.json with author object', function() {
+
+    before(function(done) {
+      helpers.run(libs.GENERATOR_PATH)
+        .inTmpDir(function(dir) {
+          fs.copySync(path.join(__dirname, '../fixtures/author'), dir);
+        })
+        .withOptions(libs.options({force: true}))
+        .withPrompts({
+          name: 'nomen',
+          author: 'ignore me',
+          description: 'it is a plugin'
+        })
+        .on('end', libs.onEnd.bind(this, done));
+    });
+
+    it('does not change the value of the author field', function() {
+      let author = this.pkg.author;
+
+      assert.ok(_.isPlainObject(author), 'the author is still an object');
+
+      assert.strictEqual(
+        author.name,
+        'John Doe',
+        'the author\'s name is correct'
+      );
+
+      assert.strictEqual(
+        author.email,
+        'john@doe.com',
+        'the author\'s email is correct'
+      );
+    });
+  });
+
   describe('package.json merging', function() {
     let result = packageJSON({
       a: 1,
@@ -196,4 +233,3 @@ describe('videojs-plugin:app', function() {
     });
   });
 });
-


### PR DESCRIPTION
This resolves the situation where an existing package.json has an author field, but it is an object instead of a string. In this case, the prompt is skipped.

Also includes some code cleanup that doesn't change behavior in any way.

Fixes #10