### PR TITLE
Remove years from copyrights

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -390,8 +390,7 @@ export default yeoman.generators.Base.extend({
       licenseName: this._licenseNames[configs.license],
       packageName: this._getPackageName(configs.name, configs.scope),
       pluginName: this._getPackageName(configs.name),
-      version: this._currentPkgJSON && this._currentPkgJSON.version || '0.0.0',
-      year: (new Date()).getFullYear()
+      version: this._currentPkgJSON && this._currentPkgJSON.version || '0.0.0'
     });
   },
 

--- a/src/app/templates/licenses/_apache2
+++ b/src/app/templates/licenses/_apache2
@@ -1,4 +1,4 @@
-Copyright <%= year %> <%= author %>
+Copyright <%= author %>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/app/templates/licenses/_mit
+++ b/src/app/templates/licenses/_mit
@@ -1,4 +1,4 @@
-Copyright (c) <%= year %> <%= author %>
+Copyright (c) <%= author %>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/test/app.test.js
+++ b/src/test/app.test.js
@@ -215,8 +215,7 @@ describe('videojs-plugin:app', function() {
       packageName: `videojs-test`,
       pluginName: 'test',
       sass: false,
-      version: '1.2.3',
-      year: '2016'
+      version: '1.2.3'
     });
 
     it('overrides properties as expected', function() {


### PR DESCRIPTION
It turns out that a copyright doesn't need a year. This is easier than keeping it updated! 

Fixes #55