### PR TITLE
remove direct specification of karma plugins

### DIFF
--- a/src/app/templates/test/_karma.conf.js
+++ b/src/app/templates/test/_karma.conf.js
@@ -1,34 +1,23 @@
 module.exports = function(config) {
-  var browsers = config.browsers;
-  var frameworks = ['qunit'];
-  var plugins = ['karma-qunit'];
-
-  var addBrowserLauncher = function(browser) {
-    plugins.push('karma-' + browser.toLowerCase() + '-launcher');
+  var detectBrowsers = {
+    enabled: false,
+    usePhantomJS: false
   };
 
   // On Travis CI, we can only run in Firefox.
   if (process.env.TRAVIS) {
-    browsers = ['Firefox'];
-    browsers.forEach(addBrowserLauncher);
+    config.browsers = ['Firefox'];
+  }
 
-  // If specific browsers are requested on the command line, load their
-  // launchers.
-  } else if (browsers.length) {
-    browsers.forEach(addBrowserLauncher);
-
-  // If no browsers are specified, we will do a `karma-detect-browsers` run,
-  // which means we need to set up that plugin and all the browser plugins
-  // we are supporting.
-  } else {
-    frameworks.push('detectBrowsers');
-    plugins.push('karma-detect-browsers');
-    ['chrome', 'firefox', 'ie', 'safari'].forEach(addBrowserLauncher);
+  // If no browsers are specified, we enable `karma-detect-browsers`
+  // this will detect all browsers that are available for testing
+  if (!config.browsers.length) {
+    detectBrowsers.enabled = true;
   }
 
   config.set({
     basePath: '..',
-    frameworks: frameworks,
+    frameworks: ['qunit', 'detectBrowsers'],
 
     files: [
 <% if (sass) { -%>
@@ -41,13 +30,7 @@ module.exports = function(config) {
       'test/dist/bundle.js'
     ],
 
-    browsers: browsers,
-    plugins: plugins,
-
-    detectBrowsers: {
-      usePhantomJS: false
-    },
-
+    detectBrowsers: detectBrowsers,
     reporters: ['dots'],
     port: 9876,
     colors: true,


### PR DESCRIPTION
As per the [documentation](https://karma-runner.github.io/0.13/config/plugins.html)
> By default, Karma loads all sibling NPM modules which have a name starting with karma-*.

So I have removed all references to plugins from the karma config as well as making the logic for wether to use detectBrowser simpler by using the enabled option.