### PR TITLE
Don't lint scripts

### DIFF
--- a/src/app/package-json.js
+++ b/src/app/package-json.js
@@ -193,6 +193,7 @@ const packageJSON = (current, context) => {
         'dist',
         'docs',
         'es5',
+        'scripts',
         'test/dist',
         'test/karma.conf.js'
       ]

--- a/src/app/templates/scripts/_server.js
+++ b/src/app/templates/scripts/_server.js
@@ -54,6 +54,8 @@ const tasks = {
 <% if (sass) { -%>
 
   sass(resolve, reject) {
+    const finish = (err) => err ? reject(err.message) : resolve();
+
     sass.render({
       file: srces.css,
       outputStyle: 'compressed'
@@ -61,13 +63,7 @@ const tasks = {
       if (err) {
         reject(err.message);
       } else {
-        fs.writeFile(dests.css, result.css, (errr) => {
-          if (errr) {
-            reject(errr.message);
-          } else {
-            resolve();
-          }
-        });
+        fs.writeFile(dests.css, result.css, finish);
       }
     });
   },

--- a/src/app/templates/scripts/_server.js
+++ b/src/app/templates/scripts/_server.js
@@ -61,9 +61,9 @@ const tasks = {
       if (err) {
         reject(err.message);
       } else {
-        fs.writeFile(dests.css, result.css, (err) => {
-          if (err) {
-            reject(err.message);
+        fs.writeFile(dests.css, result.css, (errr) => {
+          if (errr) {
+            reject(errr.message);
           } else {
             resolve();
           }


### PR DESCRIPTION
There have been too many issues with generated code failing linting; so, rather than a bunch of patches to fix virtually pointless problems, let's just not lint the `scripts/` directory.

Fixes #77 