### PR TITLE
Add rollup to the generator (NOT READY FOR MERGE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ To learn more about video.js plugins and this generator's standards and opinions
     - [Install](#install)
     - [Prompt](#prompt)
     - [Hurry](#hurry)
+    - [Limiting Generated Files](#limiting-generated-files)
     - [Brightcove Defaults](#brightcove-defaults)
 - [Updating an Existing Project](#updating-an-existing-project)
   - [Recommendations](#recommendations)

--- a/src/app/index.js
+++ b/src/app/index.js
@@ -313,7 +313,8 @@ export default yeoman.generators.Base.extend({
       'scripts/_version.js',
       '_.editorconfig',
       '_.gitignore',
-      '_.npmignore'
+      '_.npmignore',
+      '_.babelrc'
     ];
 
     this._templatesToCopy = [

--- a/src/app/package-json.js
+++ b/src/app/package-json.js
@@ -9,9 +9,11 @@ const DEFAULTS = {
   },
   devDependencies: {
 
-    // Sticking with Babel 5 for now. No significantly compelling reason to upgrade.
-    'babel': '^5.8.35',
-    'babelify': '^6.4.0',
+    'babel-cli': '^6.14.0',
+    'babel-plugin-transform-object-assign': '^6.8.0',
+    'babel-preset-es2015': '^6.14.0',
+    'babel-preset-es2015-loose': '^7.0.0',
+    'babelify': '^7.3.0',
     'bannerize': '^1.0.2',
     'bluebird': '^3.2.2',
 

--- a/src/app/package-json.js
+++ b/src/app/package-json.js
@@ -18,6 +18,7 @@ const DEFAULTS = {
     'bluebird': '^3.2.2',
 
     // browserify-shim wants browserify < 13.
+    'rollupify': '^0.3.4',
     'browserify': '^12.0.2',
     'browserify-shim': '^3.8.12',
     'browserify-versionify': '^1.0.6',
@@ -120,39 +121,45 @@ const packageJSON = (current, context) => {
     'name': context.packageName,
     'version': context.version,
     'description': context.description,
-    'main': 'es5/plugin.js',
+    'main': 'dist/npm/plugin.js',
+    'jsnext:main': 'src/plugin.js',
 
     'scripts': _.assign({}, current.scripts, {
       'prebuild': 'npm run clean',
       'build': 'npm-run-all -p build:*',
 
       'build:js': scriptify([
-        'npm-run-all',
-        'build:js:babel',
-        'build:js:browserify',
-        'build:js:bannerize',
-        'build:js:uglify'
+        'npm-run-all -p',
+        'build:js:npm',
+        'build:js:browser'
       ]),
 
-      'build:js:babel': 'babel src -d es5',
+      'build:js:npm': 'babel src -d dist/npm',
 
-      'build:js:bannerize': scriptify([
-        'bannerize dist/%s.js',
+      'build:js:browser': scriptify([
+        'npm-run-all',
+        'build:js:browser:browserify',
+        'build:js:browser:bannerize',
+        'build:js:browser:uglify'
+      ]),
+
+      'build:js:browser:browserify': scriptify([
+        'browserify src/plugin.js -s %s -o dist/browser/%s.js'
+      ]),
+
+      'build:js:browser:bannerize': scriptify([
+        'bannerize dist/browser/%s.js',
         '--banner=scripts/banner.ejs'
       ]),
 
-      'build:js:browserify': scriptify([
-        'browserify . -s %s -o dist/%s.js'
-      ]),
-
-      'build:js:uglify': scriptify([
-        'uglifyjs dist/%s.js',
-        '--comments --mangle --compress',
+      'build:js:browser:uglify': scriptify([
+        'uglifyjs dist/browser/%s.js',
+        '-c -m --comments',
         '-o dist/%s.min.js'
       ]),
 
       'build:test': 'babel-node scripts/build-test.js',
-      'clean': 'rimraf dist test/dist es5 && mkdirp dist test/dist es5',
+      'clean': 'rimraf dist && mkdirp dist/test dist/npm dist/browser',
       'lint': 'vjsstandard',
       'prepublish': 'npm run build',
       'start': 'babel-node scripts/server.js',
@@ -172,6 +179,8 @@ const packageJSON = (current, context) => {
 
     'browserify': {
       transform: [
+        'rollupify',
+        'babelify',
         'browserify-shim',
         'browserify-versionify'
       ]
@@ -184,10 +193,10 @@ const packageJSON = (current, context) => {
     },
 
     // These objects are used as a reference to the browser-global providers.
-    'style': scriptify('dist/%s.css'),
+    'style': scriptify('dist/browser/%s.css'),
     'videojs-plugin': {
-      style: scriptify('dist/%s.css'),
-      script: scriptify('dist/%s.min.js')
+      style: scriptify('dist/browser/%s.css'),
+      script: scriptify('dist/browser/%s.min.js')
     },
 
     'vjsstandard': {
@@ -239,13 +248,13 @@ const packageJSON = (current, context) => {
       'build:css': 'npm-run-all build:css:sass build:css:bannerize',
 
       'build:css:bannerize': scriptify([
-        'bannerize dist/%s.css --banner=scripts/banner.ejs'
+        'bannerize dist/browser/%s.css --banner=scripts/banner.ejs'
       ]),
 
       'build:css:sass': scriptify([
         'node-sass',
         'src/plugin.scss',
-        'dist/%s.css',
+        'dist/browser/%s.css',
         '--output-style=compressed',
         '--linefeed=lf'
       ])

--- a/src/app/templates/_.babelrc
+++ b/src/app/templates/_.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015-loose"],
+  "plugins": ["transform-object-assign"]
+}

--- a/src/app/templates/scripts/_build-test.js
+++ b/src/app/templates/scripts/_build-test.js
@@ -9,7 +9,6 @@ glob('test/**/*.test.js', (err, files) => {
     throw err;
   }
   browserify(files)
-    .transform('babelify')
     .bundle()
-    .pipe(fs.createWriteStream('test/dist/bundle.js'));
+    .pipe(fs.createWriteStream('dist/test/bundle.js'));
 });

--- a/src/app/templates/scripts/_server.js
+++ b/src/app/templates/scripts/_server.js
@@ -34,13 +34,13 @@ const srces = {
 
 const dests = {
 <% if (sass) { -%>
-  css: nameify('dist/%s.css'),
+  css: nameify('dist/browser/%s.css'),
 <% } -%>
-  js: nameify('dist/%s.js'),
+  js: nameify('dist/browser/%s.js'),
 <% if (lang) { -%>
   langs: 'dist/lang',
 <% } -%>
-  tests: 'test/dist/bundle.js'
+  tests: 'dist/test/bundle.js'
 };
 
 const tasks = {
@@ -77,21 +77,11 @@ const tasks = {
     debug: true,
     entries: [srces.js],
     standalone: nameify('%s'),
-    transform: [
-      'babelify',
-      'browserify-shim',
-      'browserify-versionify'
-    ]
   }),
 
   tests: browserify({
     debug: true,
     entries: srces.tests,
-    transform: [
-      'babelify',
-      'browserify-shim',
-      'browserify-versionify'
-    ]
   })
 };
 
@@ -216,7 +206,7 @@ build(['js', 'tests']).then(() => {
       'src/**/*.js',
 <% } -%>
       'test/**/*.js',
-      '!test/dist/**/*.js',
+      '!dist/test/**/*.js',
       'test/index.html'
     ])
     .on('watch', (event, file) => {

--- a/src/app/templates/test/_karma.conf.js
+++ b/src/app/templates/test/_karma.conf.js
@@ -1,3 +1,4 @@
+var pkg = require('../package.json');
 module.exports = function(config) {
   var detectBrowsers = {
     enabled: false,
@@ -21,13 +22,13 @@ module.exports = function(config) {
 
     files: [
 <% if (sass) { -%>
-      'dist/<%= pluginName %>.css',
+      'dist/browser/' + pkg.name + '.css',
 <% } -%>
       'node_modules/sinon/pkg/sinon.js',
       'node_modules/sinon/pkg/sinon-ie.js',
       'node_modules/video.js/dist/video.js',
       'node_modules/video.js/dist/video-js.css',
-      'test/dist/bundle.js'
+      'dist/test/bundle.js'
     ],
 
     detectBrowsers: detectBrowsers,

--- a/src/test/app.test.js
+++ b/src/test/app.test.js
@@ -45,7 +45,7 @@ describe('videojs-plugin:app', function() {
       assert.strictEqual(this.pkg.name, 'videojs-wat');
       assert.strictEqual(this.pkg.description, 'wat is the plugin');
       assert.strictEqual(this.pkg.version, '0.0.0');
-      assert.strictEqual(this.pkg.main, 'es5/plugin.js');
+      assert.strictEqual(this.pkg.main, 'dist/npm/plugin.js');
       assert.ok(_.isArray(this.pkg.keywords));
       assert.ok(_.isPlainObject(this.pkg['browserify-shim']));
       assert.ok(_.isPlainObject(this.pkg.vjsstandard));

--- a/src/test/libs.js
+++ b/src/test/libs.js
@@ -19,6 +19,7 @@ const FILES = {
     '.editorconfig',
     '.gitignore',
     '.npmignore',
+    '.babelrc',
     'CHANGELOG.md',
     'CONTRIBUTING.md',
     'index.html',


### PR DESCRIPTION
* do we want to have `dist/{test,npm,browser}`? or do we want to serve a single concatenated file from rollup on npm? IMO we want to have an npm dir so that the user can require any module they want in the project without jumping through hoops. 
 based on #86 