### PR TITLE
feat: Add prompt for selecting plugin type - basic (default) or advanced.

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -149,6 +149,12 @@ module.exports = yeoman.generators.Base.extend({
       default: defaults.type,
       choices: utils.objectToChoices(this._types)
     }, {
+      type: 'list',
+      name: 'type',
+      message: 'Choose a plugin type',
+      default: defaults.type,
+      choices: utils.objectToChoices(this._types)
+    }, {
       type: 'confirm',
       name: 'css',
       message: 'Do you want to include CSS styling, including Sass preprocessing?',

--- a/generators/app/package-json.js
+++ b/generators/app/package-json.js
@@ -172,7 +172,7 @@ module.exports = (current, context) => {
   }
 
   if (context.type !== 'basic') {
-    result.dependencies['video.js'] = '>=6.0.0-RC.0';
+    result.dependencies['video.js'] = '^6.0.1';
   }
 
   result.files.sort();


### PR DESCRIPTION
This outputs a boilerplate advanced plugin, if requested. Still defaults to a basic plugin.