### PR TITLE
fix: bring doc precommit from 5s to 1s

### DIFF
--- a/generators/app/package-json.js
+++ b/generators/app/package-json.js
@@ -278,7 +278,7 @@ const packageJSON = (current, context) => {
     });
 
     if (context.husky !== 'none') {
-      result.scripts.precommit = 'npm run docs && git add README.md';
+      result.scripts.precommit = 'npm run docs:toc && git add README.md';
     }
 
     _.assign(result.devDependencies, {


### PR DESCRIPTION
we dont need to generate api docs every commit since they shouldn't be in the repo anyway