### PR TITLE
fix: set global as external during watch, to prevent an error

### DIFF
--- a/generators/app/templates/scripts/_modules.rollup.config.js
+++ b/generators/app/templates/scripts/_modules.rollup.config.js
@@ -11,7 +11,7 @@ import json from 'rollup-plugin-json';
 export default {
   moduleName: '<%= moduleName %>',
   entry: 'src/plugin.js',
-  external: ['video.js'],
+  external: ['video.js', 'global'],
   globals: {
     'video.js': 'videojs'
   },


### PR DESCRIPTION
The first build of js-modules passes, but subsequent builds fail due to a [bug in rollup that has yet to be resolved](https://github.com/rollup/rollup/issues/982). Since we don't bundle global in the module build anyway we can set it as external and stop the error from happening.