### PR TITLE
fix: broken watch as of sass 4.6.0

### DIFF
--- a/generators/app/package-json.js
+++ b/generators/app/package-json.js
@@ -265,7 +265,7 @@ const packageJSON = (current, context) => {
       ])
     });
 
-    result.devDependencies['node-sass'] = '^4.5.3';
+    result.devDependencies['node-sass'] = '4.5.3';
   }
 
   // Support the documentation tooling option.


### PR DESCRIPTION
`4.6.0` breaks watch
`4.5.3` is fine
https://github.com/sass/node-sass/issues/2139