### PR TITLE
revert: fix: Tick 2ms in tests for player ready, see https://github.com/videojs/video.js/pull/4665 (#136)

### DIFF
--- a/generators/app/templates/test/_plugin.test.js
+++ b/generators/app/templates/test/_plugin.test.js
@@ -49,7 +49,7 @@ QUnit.test('registers itself with video.js', function(assert) {
   this.player.<%= functionName %>();
 
   // Tick the clock forward enough to trigger the player to be "ready".
-  this.clock.tick(2);
+  this.clock.tick(1);
 
   assert.ok(
     this.player.hasClass('<%= className %>'),


### PR DESCRIPTION
This reverts commit 87f0d08119a825098e944e37a20d95596306eae2.