### PR TITLE
refactor: Make sure Node versions are consistent.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: node_js
 node_js:
-  - 'node'
-  - 'lts/argon'
+  - '8'
+  - '4.8'

--- a/generators/app/templates/_.travis.yml
+++ b/generators/app/templates/_.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 dist: trusty
 language: node_js
 node_js:
-  - 'node'
-  - 'lts/argon'
+  - '8'
+  - '4.8'
 before_script:
 
   # Check if the current version is equal to the major version for the env.

--- a/generators/app/templates/_CONTRIBUTING.md
+++ b/generators/app/templates/_CONTRIBUTING.md
@@ -6,7 +6,7 @@ We welcome contributions from everyone!
 <% } -%>
 ## Getting Started
 
-Make sure you have NodeJS 0.10 or higher and npm installed.
+Make sure you have Node.js 4.8 or higher and npm installed.
 
 <% if (!isPrivate) { -%>
 1. Fork this repository and clone your fork


### PR DESCRIPTION
The `engine` field in `package.json` for running the generator indicates that generated projects require Node 4.8 or better, but this doesn't match the `CONTRIBUTING.md`.

Closes #135 