### PR TITLE
feat: Support Video.js 7 only and move to `peerDependencies`.

### DIFF
--- a/generators/app/package-json.js
+++ b/generators/app/package-json.js
@@ -159,7 +159,7 @@ const packageJSON = (current, context) => {
       'prepublish': 'not-in-install && npm run build || in-install',
       'start': 'npm-run-all -p server watch',
       'server': 'karma start scripts/karma.conf.js --singleRun=false --auto-watch --no-browsers',
-      'pretest': 'npm run lint',
+      'pretest': 'npm-run-all lint',
       'test': 'karma start scripts/karma.conf.js',
       'preversion': 'npm test',
       'version': 'node scripts/version.js',
@@ -223,6 +223,7 @@ const packageJSON = (current, context) => {
   }
 
   if (context.css) {
+    result.scripts.pretest += ' postclean build:css';
 
     _.assign(result.scripts, {
       'build:css': scriptify('postcss --verbose -o dist/%s.css --config scripts/postcss.config.js src/plugin.css'),
@@ -248,6 +249,12 @@ const packageJSON = (current, context) => {
   // here because the videojs-languages package will create the destination
   // directory if needed.
   if (context.lang) {
+    if (!context.docs) {
+      result.scripts.pretest += ' postclean';
+
+    }
+
+    result.scripts.pretest += ' build:lang';
     result.scripts['build:lang'] = 'vjslang --dir dist/lang';
     _.assign(result.devDependencies, getGeneratorVersions(['videojs-languages']));
   }

--- a/generators/app/package-json.js
+++ b/generators/app/package-json.js
@@ -27,6 +27,7 @@ const DEFAULTS = {
   dependencies: getGeneratorVersions(['global']),
   peerDependencies: getGeneratorVersions(['video.js']),
   devDependencies: getGeneratorVersions([
+    'video.js',
     'babel-core',
     'babel-plugin-external-helpers',
     'babel-plugin-transform-object-assign',
@@ -191,12 +192,8 @@ const packageJSON = (current, context) => {
     ],
 
     'dependencies': _.assign({}, current.dependencies, DEFAULTS.dependencies),
-
-    'devDependencies': _.assign(
-      {},
-      current.devDependencies,
-      DEFAULTS.devDependencies
-    )
+    'peerDependencies': _.assign({}, current.peerDependencies, DEFAULTS.peerDependencies),
+    'devDependencies': _.assign({}, current.devDependencies, DEFAULTS.devDependencies)
   });
 
   // In case husky was previously installed, but is now "none", we can
@@ -259,6 +256,7 @@ const packageJSON = (current, context) => {
   result.scripts = alphabetizeScripts(result.scripts);
   result.dependencies = alphabetizeObject(result.dependencies);
   result.devDependencies = alphabetizeObject(result.devDependencies);
+  result.peerDependencies = alphabetizeObject(result.peerDependencies);
 
   return result;
 };

--- a/generators/app/package-json.js
+++ b/generators/app/package-json.js
@@ -24,7 +24,8 @@ const getGeneratorVersions = (pkgList) => pkgList.reduce((acc, pkgName) => {
 }, {});
 
 const DEFAULTS = {
-  dependencies: getGeneratorVersions(['global', 'video.js']),
+  dependencies: getGeneratorVersions(['global']),
+  peerDependencies: getGeneratorVersions(['video.js']),
   devDependencies: getGeneratorVersions([
     'babel-core',
     'babel-plugin-external-helpers',

--- a/generators/app/templates/_.travis.yml
+++ b/generators/app/templates/_.travis.yml
@@ -4,24 +4,9 @@ language: node_js
 node_js:
   - 'lts/*'
 before_script:
-
-  # Check if the current version is equal to the major version for the env.
-  - 'export IS_INSTALLED="$(npm list video.js | grep "video.js@$VJS")"'
-
-  # We have to add semicolons to the end of each line in the if as Travis runs
-  # this all on one line.
-  - 'if [ -z "$IS_INSTALLED" ]; then
-      echo "INSTALLING video.js@>=$VJS.0.0-RC.0 <$(($VJS+1)).0.0";
-      npm i "video.js@>=$VJS.0.0-RC.0 <\$(($VJS+1)).0.0";
-    else
-      echo "video.js@$VJS ALREADY INSTALLED";
-    fi'
   - export CHROME_BIN=/usr/bin/google-chrome
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
-env:
-  - VJS=5
-  - VJS=6
 addons:
   firefox: latest
   apt:

--- a/generators/app/templates/_index.html
+++ b/generators/app/templates/_index.html
@@ -20,7 +20,7 @@
   <script>
     (function(window, videojs) {
       var player = window.player = videojs('<%= pluginName %>-player');
-      player.<%= pluginFunctionName %>();
+      var <%= pluginFunctionName %> = window.<%= pluginFunctionName %> = player.<%= pluginFunctionName %>();
     }(window, window.videojs));
   </script>
 </body>

--- a/generators/app/templates/src/_plugin-basic.js
+++ b/generators/app/templates/src/_plugin-basic.js
@@ -4,10 +4,6 @@ import {version as VERSION} from '../package.json';
 // Default options for the plugin.
 const defaults = {};
 
-// Cross-compatibility for Video.js 5 and 6.
-const registerPlugin = videojs.registerPlugin || videojs.plugin;
-// const dom = videojs.dom || videojs;
-
 /**
  * Function to invoke when the player is ready.
  *
@@ -45,7 +41,7 @@ const <%= pluginFunctionName %> = function(options) {
 };
 
 // Register the plugin with video.js.
-registerPlugin('<%= pluginFunctionName %>', <%= pluginFunctionName %>);
+videojs.registerPlugin('<%= functionName %>', <%= functionName %>);
 
 // Include the version number.
 <%= pluginFunctionName %>.VERSION = VERSION;

--- a/generators/app/templates/src/_plugin-basic.js
+++ b/generators/app/templates/src/_plugin-basic.js
@@ -41,7 +41,7 @@ const <%= pluginFunctionName %> = function(options) {
 };
 
 // Register the plugin with video.js.
-videojs.registerPlugin('<%= functionName %>', <%= functionName %>);
+videojs.registerPlugin('<%= pluginFunctionName %>', <%= pluginFunctionName %>);
 
 // Include the version number.
 <%= pluginFunctionName %>.VERSION = VERSION;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6906,9 +6906,9 @@
       }
     },
     "util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.11.0.tgz",
+      "integrity": "sha512-5n12uMzKCjvB2HPFHnbQSjaqAa98L5iIXmHrZCLavuZVe0qe/SJGbDGWlpaHk5lnBkWRDO+dRu1/PgmUYKPPTw==",
       "requires": {
         "inherits": "2.0.3"
       }
@@ -7382,7 +7382,7 @@
             "formatio": "1.1.1",
             "lolex": "1.3.2",
             "samsam": "1.1.2",
-            "util": "0.10.4"
+            "util": "0.11.0"
           }
         },
         "supports-color": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "semver": "^5.4.1",
     "sinon": "^5.1.0",
     "uglify-es": "^3.3.9",
-    "video.js": "^5.19.2 || ^6.6.0 || ^7.0.3",
+    "video.js": "^7.0.3",
     "videojs-languages": "^1.0.0"
   }
 }

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -199,7 +199,8 @@ describe('videojs-plugin:app', function() {
     it('(generator) has no extra optional deps', function() {
       const optionalPackages = Object.keys(generatorPkg.optionalDependencies);
       const packages = Object.keys(this.pkg.dependencies)
-        .concat(Object.keys(this.pkg.devDependencies));
+        .concat(Object.keys(this.pkg.devDependencies))
+        .concat(Object.keys(this.pkg.peerDependencies));
       let i = optionalPackages.length;
 
       while (i--) {


### PR DESCRIPTION
Fixes #146

BREAKING CHANGE: This removes cross-version support between Video.js 5 and 6.