### PR TITLE
fix: do not exclude node modules from babel

### DIFF
--- a/generators/app/templates/scripts/_rollup.config.js
+++ b/generators/app/templates/scripts/_rollup.config.js
@@ -20,7 +20,9 @@ const banner = `/*! @name ${pkg.name} @version ${pkg.version} @license ${pkg.lic
 const primedPlugins = {
   babel: babel({
     babelrc: false,
-    exclude: 'node_modules/**',
+    // you may want to manually exclude non-es6 modules
+    // if your build is slow
+    exclude: [],
     presets: [
       ['env', {loose: true, modules: false, targets: {browsers: pkg.browserslist}}]
     ],


### PR DESCRIPTION
In order to get many of the size benefits from rollup/es6 code we want to use es6 versions of sub modules. Right now that is what we do, but it causes syntax errors (especially on ie 11) since anything in node_modules won't be converted to es5 and will remain es6.