### PR TITLE
fix: requirejs by not trying to load video.js with it

### DIFF
--- a/generators/app/templates/_README.md
+++ b/generators/app/templates/_README.md
@@ -54,10 +54,25 @@ player.<%= pluginFunctionName %>();
 When using with RequireJS (or another AMD library), get the script in whatever way you prefer and `require` the plugin as you normally would:
 
 ```js
-require(['video.js', '<%= packageName %>'], function(videojs) {
-  var player = videojs('my-video');
+// configure the paths to the packages with requirejs
+requirejs.config({
+  paths: {
+    "videojs": "videojs-url",
+    "<%= pluginFunctionName %>": "plugin-url",
+  },
+});
 
-  player.<%= pluginFunctionName %>();
+// first require videojs (unless you included it as a script on the page)
+requirejs(['videojs'], function(videojs) {
+  // add videojs to window
+  window.videojs = videojs;
+
+  // then require this plugin, as it expects a global videojs on window.
+  requirejs(['<%= pluginFunctionName %>'], function(<%= pluginFunctionName %>) {
+    var player = videojs('my-video');
+
+    console.log(player.<%= pluginFunctionName %>);
+  });
 });
 ```
 

--- a/generators/app/templates/scripts/_rollup.config.js
+++ b/generators/app/templates/scripts/_rollup.config.js
@@ -112,6 +112,13 @@ const makeBuild = (name, settings) => {
     input: 'src/plugin.js'
   }, settings);
 
+  if (name === 'umd') {
+    // without the following code requirejs will break.
+    // eventually we will switch this to an iife, since
+    // that is basically what we use anyway.
+    b.amd = {define: 'null'};
+  }
+
   const fixOutput = (o) => {
     if (!o.banner) {
       o.banner = `/*! @name ${pkg.name} @version ${pkg.version} @license ${pkg.license} */`;


### PR DESCRIPTION
Basically requirejs tries to handle `video.js` as a local file and in the past we have just had requirejs refer to it as `videojs` but we cannot do that. Instead we are
Here is a snippet of the code:

`typeof define === 'function' && define.amd ? define(['video.js']` 
becomes:
`typeof null === 'function' && null.amd ? null(['video.js']` 