### PR TITLE
fix: use npm-merge-driver-install to fix install issues

### DIFF
--- a/generators/app/package-json.js
+++ b/generators/app/package-json.js
@@ -38,7 +38,7 @@ const DEFAULTS = {
     'not-prerelease',
     'sinon',
     'videojs-standard',
-    'npm-merge-driver',
+    'npm-merge-driver-install',
     'husky',
     'lint-staged',
     'pkg-ok'
@@ -143,7 +143,6 @@ const packageJSON = (current, context) => {
       'postclean': 'shx mkdir -p ./dist ./test/dist',
       'lint': 'vjsstandard',
       'prepublish': 'not-in-install && npm run build && pkg-ok || in-install',
-      'postinstall': 'shx test -d .git && npm-merge-driver install || in-install',
       'start': 'npm-run-all -p server watch',
       'server': 'karma start scripts/karma.conf.js --singleRun=false --auto-watch',
       'pretest': 'npm-run-all lint build',

--- a/package-lock.json
+++ b/package-lock.json
@@ -4394,6 +4394,16 @@
         }
       }
     },
+    "npm-merge-driver-install": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/npm-merge-driver-install/-/npm-merge-driver-install-1.0.0.tgz",
+      "integrity": "sha512-SY76gdxa6qJv6Hd+IayKU7FY2BJw+SR+kJyHnwgyUjXCEEFJ7JGcE+HZiYfW4vq76ypaZRnDxTeZkSF3/Z0PJw==",
+      "dev": true,
+      "requires": {
+        "is-ci": "1.2.0",
+        "npm-merge-driver": "2.3.5"
+      }
+    },
     "npm-path": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "test:unit": "mocha test/*.test.js",
     "test:integration": "node scripts/run-integration-tests.js",
     "version": "is-prerelease || npm run update-changelog && git add CHANGELOG.md",
-    "update-changelog": "conventional-changelog -p videojs -i CHANGELOG.md -s",
-    "prepublish": "in-install && npm-merge-driver install || not-in-install"
+    "update-changelog": "conventional-changelog -p videojs -i CHANGELOG.md -s"
   },
   "lint-staged": {
     "*.js": [
@@ -61,7 +60,7 @@
     "lint-staged": "^7.2.2",
     "mocha": "^5.2.0",
     "not-prerelease": "^1.0.1",
-    "npm-merge-driver": "^2.3.5",
+    "npm-merge-driver-install": "^1.0.0",
     "npm-run-all": "^4.1.3",
     "pkg-ok": "^2.2.0",
     "videojs-standard": "^7.0.1",


### PR DESCRIPTION
Currently the generator is broken because a packages that try to install another packages will run the `postinstall` script on install. This tries to install `npm-merge-driver` and it is a `devDependency` so it will error out.

Fixes #227 