### PR TITLE
fix: jsdoc security issue

### DIFF
--- a/plugin/package-lock.json
+++ b/plugin/package-lock.json
@@ -5892,8 +5892,8 @@
       }
     },
     "jsdoc": {
-      "version": "git+https://github.com/BrandonOCasey/jsdoc.git#da41874b82ee87a28b4f615cf5306c6f84e53d57",
-      "from": "git+https://github.com/BrandonOCasey/jsdoc.git#feat/plugin-from-cli",
+      "version": "git+https://github.com/BrandonOCasey/jsdoc.git#c9e3b2cff21f505ff3a3d5622ae09595e1199b06",
+      "from": "git+https://github.com/BrandonOCasey/jsdoc.git#fix/security-issue",
       "dev": true,
       "requires": {
         "babylon": "7.0.0-beta.19",
@@ -5903,7 +5903,7 @@
         "js2xmlparser": "~3.0.0",
         "klaw": "~2.0.0",
         "markdown-it": "~8.3.1",
-        "markdown-it-named-headers": "~0.0.4",
+        "markdown-it-anchor": "^5.0.0",
         "marked": "~0.3.6",
         "mkdirp": "~0.5.1",
         "requizzle": "~0.2.1",
@@ -6709,14 +6709,11 @@
         "uc.micro": "^1.0.3"
       }
     },
-    "markdown-it-named-headers": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/markdown-it-named-headers/-/markdown-it-named-headers-0.0.4.tgz",
-      "integrity": "sha1-gu/CgyQkCmsed7mq5QF3HV81HB8=",
-      "dev": true,
-      "requires": {
-        "string": "^3.0.1"
-      }
+    "markdown-it-anchor": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.0.2.tgz",
+      "integrity": "sha512-AFM/woBI8QDJMS/9+MmsBMT5/AR+ImfOsunQZTZhzcTmna3rIzAzbOh5E0l6mlFM/i9666BpUtkqQ9bS7WApCg==",
+      "dev": true
     },
     "markdown-table": {
       "version": "0.4.0",
@@ -6738,7 +6735,7 @@
     },
     "marked": {
       "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
+      "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
       "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
       "dev": true
     },
@@ -10348,12 +10345,6 @@
           "dev": true
         }
       }
-    },
-    "string": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/string/-/string-3.3.3.tgz",
-      "integrity": "sha1-XqIRzZLSKOGEKUmQpsyXs2anfLA=",
-      "dev": true
     },
     "string-argv": {
       "version": "0.0.2",

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -17,7 +17,7 @@
     "conventional-changelog-videojs": "^3.0.0",
     "doctoc": "^1.3.1",
     "husky": "^1.0.1",
-    "jsdoc": "https://github.com/BrandonOCasey/jsdoc#feat/plugin-from-cli",
+    "jsdoc": "https://github.com/BrandonOCasey/jsdoc#fix/security-issue",
     "karma": "^3.0.0",
     "lint-staged": "^7.2.2",
     "not-prerelease": "^1.0.1",


### PR DESCRIPTION
This branch still includes the global plugin changes

See the diff:
* https://github.com/BrandonOCasey/jsdoc/compare/feat/plugin-from-cli...BrandonOCasey:fix/security-issue?expand=1

TL;DR
* jsdoc is dead but one of the deps it uses is not maintained, I switched it to a drop in replacement.