### PR TITLE
Use a different name for player in the test page

### DIFF
--- a/generators/app/templates/_index.html
+++ b/generators/app/templates/_index.html
@@ -19,8 +19,8 @@
   <script src="dist/<%= pluginName %>.js"></script>
   <script>
     (function(window, videojs) {
-      var player = window.player = videojs('<%= pluginName %>-player');
-      var <%= pluginFunctionName %> = window.<%= pluginFunctionName %> = player.<%= pluginFunctionName %>();
+      var examplePlayer = window.examplePlayer = videojs('<%= pluginName %>-player');
+      var <%= pluginFunctionName %> = window.<%= pluginFunctionName %> = examplePlayer.<%= pluginFunctionName %>();
     }(window, window.videojs));
   </script>
 </body>


### PR DESCRIPTION
Setting `window.player` in index.html can mask some problems while testing in the browser, such as using `player` in a component instead of `this.player_`.

This uses `examplePlayer` instead.