### PR TITLE
Updated npm-run-all from 4.1.3 to 4.1.5 so that event-stream@3.3.6 not used.

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -22,7 +22,7 @@
     "lint-staged": "^8.0.0",
     "not-prerelease": "^1.0.1",
     "npm-merge-driver-install": "^1.0.0",
-    "npm-run-all": "^4.1.3",
+    "npm-run-all": "^4.1.5",
     "postcss-cli": "^6.0.0",
     "rollup": "^0.67.1",
     "shx": "^0.3.2",


### PR DESCRIPTION
The full problem is explained in [issues/266](https://github.com/videojs/generator-videojs-plugin/issues/266).
In short, `npm install` wasn't working since the dependecy `npm-run-all` was indirectly depending on `event-stream@3.3.6` which was removed from npm because of security reasons.