### PR TITLE
fix: remove obsolete v5 compatiblity

### DIFF
--- a/generators/app/templates/src/_plugin-basic.js
+++ b/generators/app/templates/src/_plugin-basic.js
@@ -4,10 +4,6 @@ import {version as VERSION} from '../package.json';
 // Default options for the plugin.
 const defaults = {};
 
-// Cross-compatibility for Video.js 5 and 6.
-const registerPlugin = videojs.registerPlugin || videojs.plugin;
-// const dom = videojs.dom || videojs;
-
 /**
  * Function to invoke when the player is ready.
  *
@@ -45,7 +41,7 @@ const <%= pluginFunctionName %> = function(options) {
 };
 
 // Register the plugin with video.js.
-registerPlugin('<%= pluginFunctionName %>', <%= pluginFunctionName %>);
+videojs.registerPlugin('<%= pluginFunctionName %>', <%= pluginFunctionName %>);
 
 // Include the version number.
 <%= pluginFunctionName %>.VERSION = VERSION;


### PR DESCRIPTION
The dependency in package.json is `"^6 || ^7"` so the v5 compatiblity is unnecessary. 