### PR TITLE
feat: Add option to install video.js as a peerDependency

### DIFF
--- a/generators/app/constants.js
+++ b/generators/app/constants.js
@@ -52,6 +52,7 @@ module.exports = {
     library: false,
     license: LICENSE_DEFAULT,
     pluginType: 'advanced',
-    name: path.basename(process.cwd()).replace(/^videojs-/, '')
+    name: path.basename(process.cwd()).replace(/^videojs-/, ''),
+    peerDep: false
   }
 };

--- a/generators/app/generator.js
+++ b/generators/app/generator.js
@@ -145,7 +145,7 @@ module.exports = class extends Generator {
       default: defaults.pluginType,
       choices: constants.PLUGIN_TYPE_CHOICES
     }, {
-      type: 'list',
+      type: 'confirm',
       name: 'peerDep',
       message: 'Install video.js as a peerDependency and devDependency, instead of a regular dependency',
       default: defaults.peerDep

--- a/generators/app/generator.js
+++ b/generators/app/generator.js
@@ -145,6 +145,11 @@ module.exports = class extends Generator {
       default: defaults.pluginType,
       choices: constants.PLUGIN_TYPE_CHOICES
     }, {
+      type: 'list',
+      name: 'peerDep',
+      message: 'Install video.js as a peerDependency and devDependency, instead of a regular dependency',
+      default: defaults.peerDep
+    }, {
       type: 'confirm',
       name: 'css',
       message: 'Do you want to use css tooling?',

--- a/generators/app/package-json.js
+++ b/generators/app/package-json.js
@@ -22,7 +22,7 @@ const getGeneratorVersions = (pkgList) => pkgList.reduce((acc, pkgName) => {
 }, {});
 
 const DEFAULTS = {
-  dependencies: getGeneratorVersions(['global', 'video.js']),
+  dependencies: getGeneratorVersions(['global']),
   devDependencies: getGeneratorVersions([
     '@babel/runtime',
     '@videojs/generator-helpers',
@@ -191,6 +191,14 @@ const packageJSON = (current, context) => {
       DEFAULTS.devDependencies
     )
   });
+
+  // Add video.js as a dependency by default, or as both a peerDep and devDep
+  if (context.peerDep) {
+    result.peerDependencies = _.assign({}, getGeneratorVersions(['video.js']));
+    _.assign(result.devDependencies, getGeneratorVersions(['video.js']));
+  } else {
+    _.assign(result.dependencies, getGeneratorVersions(['video.js']));
+  }
 
   // In case husky was previously installed, but is now "none", we can
   // remove it from the package.json entirely.

--- a/generators/app/package-json.js
+++ b/generators/app/package-json.js
@@ -189,12 +189,14 @@ const packageJSON = (current, context) => {
       {},
       current.devDependencies,
       DEFAULTS.devDependencies
-    )
+    ),
+
+    'peerDependencies': _.assign({}, current.dependencies)
   });
 
   // Add video.js as a dependency by default, or as both a peerDep and devDep
   if (context.peerDep) {
-    result.peerDependencies = _.assign({}, getGeneratorVersions(['video.js']));
+    _.assign(result.peerDependencies, getGeneratorVersions(['video.js']));
     _.assign(result.devDependencies, getGeneratorVersions(['video.js']));
   } else {
     _.assign(result.dependencies, getGeneratorVersions(['video.js']));

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,15 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@brandonocasey/spawn-promise": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@brandonocasey/spawn-promise/-/spawn-promise-0.2.0.tgz",
+      "integrity": "sha512-6m0OpJRp3/a7080No09g/UxPsT8pObdmQrk6K9I9OU44jgN63Jml+cK/8Ehaz+4DOdrIqzmQfZfCCN4bHC6F+A==",
+      "dev": true,
+      "requires": {
+        "exit-hook": "^2.2.1"
+      }
+    },
     "@es-joy/jsdoccomment": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.7.2.tgz",
@@ -2202,9 +2211,9 @@
       }
     },
     "es-check": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/es-check/-/es-check-5.2.3.tgz",
-      "integrity": "sha512-+KiUcqXXqHk9H05l7Cg2sGrtiUyKcgY5hslm0DSb0iv6K5V/DIiRxJhvgA75TM99xO6FAIGbZSW8bAPbZDsDow==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/es-check/-/es-check-5.2.4.tgz",
+      "integrity": "sha512-FZ3qAJ9hwguqPvGGagaKAVDnusSkezeHbiKNM5rOepOjloeVuX2e6meMxQ+mKcnWbAFucCG7fszNrzUT8bvHcQ==",
       "dev": true,
       "requires": {
         "acorn": "^6.4.1",
@@ -6134,12 +6143,12 @@
       "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="
     },
     "prettyjson": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
-      "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.5.tgz",
+      "integrity": "sha512-rksPWtoZb2ZpT5OVgtmy0KHVM+Dca3iVwWY9ifwhcexfjebtgjg3wmrUt9PvJ59XIYBcknQeYHD8IAnVlh9lAw==",
       "dev": true,
       "requires": {
-        "colors": "^1.1.2",
+        "colors": "1.4.0",
         "minimist": "^1.2.0"
       },
       "dependencies": {
@@ -7223,12 +7232,20 @@
           }
         },
         "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
           "dev": true,
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "^1.2.6"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.6",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+              "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+              "dev": true
+            }
           }
         },
         "ms": {
@@ -7701,15 +7718,24 @@
       }
     },
     "videojs-generator-verify": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/videojs-generator-verify/-/videojs-generator-verify-4.0.0.tgz",
-      "integrity": "sha512-+pU+dKqjloYDJjJURZPff9HRWVr3AhffK5AfeHGnrcLLo1g0bEkU69YXNMZgRJMbWCQ45/Y8YJ5m6mZYEfrw2w==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/videojs-generator-verify/-/videojs-generator-verify-4.1.0.tgz",
+      "integrity": "sha512-PUDC4owKBtCHcEtJiaU7e8kpAbQnj7huRcakl3My8F4xfSxEierFUFCD5cJwNSJGu/Vf5uaGfYYWKt/ok4Q03Q==",
       "dev": true,
       "requires": {
-        "colorette": "^1.2.2",
-        "es-check": "^5.2.3",
+        "@brandonocasey/spawn-promise": "~0.2.0",
+        "colorette": "^2.0.16",
+        "es-check": "^5.2.4",
         "exit-hook": "^2.2.1",
         "shelljs": "^0.8.4"
+      },
+      "dependencies": {
+        "colorette": {
+          "version": "2.0.16",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+          "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+          "dev": true
+        }
       }
     },
     "videojs-standard": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "is-ci": "^3.0.0",
     "mocha": "^8.4.0",
     "@videojs/generator-helpers": "~3.0.0",
-    "videojs-generator-verify": "~4.0.0",
+    "videojs-generator-verify": "^4.1.0",
     "videojs-standard": "^9.0.0",
     "yeoman-assert": "^3.1.1",
     "yeoman-test": "^6.1.0"

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -311,6 +311,47 @@ describe('videojs-plugin:app', function() {
     });
   });
 
+  describe('video.js is regular dependency by default', function() {
+    before(function(done) {
+      helpers.run(libs.GENERATOR_PATH)
+        .withOptions(libs.options())
+        .withPrompts({
+          name: 'wat',
+          author: 'John Doe',
+          description: 'wat is the plugin'
+        })
+        .on('end', () => libs.onEnd(this, done));
+    });
+
+    it('package.json is as expected', function() {
+      assert(_.isPlainObject(this.pkg));
+      assert.strictEqual(typeof this.pkg.dependencies['video.js'], 'string');
+      assert.strictEqual(this.pkg.devDependencies['video.js'], undefined);
+      assert.strictEqual(this.pkg.peerDependencies['video.js'], undefined);
+    });
+  });
+
+  describe('video.js can be a peer and dev dependency', function() {
+    before(function(done) {
+      helpers.run(libs.GENERATOR_PATH)
+        .withOptions(libs.options())
+        .withPrompts({
+          name: 'wat',
+          author: 'John Doe',
+          description: 'wat is the plugin',
+          peerDep: true
+        })
+        .on('end', () => libs.onEnd(this, done));
+    });
+
+    it('package.json is as expected', function() {
+      assert(_.isPlainObject(this.pkg));
+      assert.strictEqual(this.pkg.dependencies['video.js'], undefined);
+      assert.strictEqual(typeof this.pkg.devDependencies['video.js'], 'string');
+      assert.strictEqual(typeof this.pkg.peerDependencies['video.js'], 'string');
+    });
+  });
+
   describe('precommit false', function() {
     before(function(done) {
       helpers.run(libs.GENERATOR_PATH)


### PR DESCRIPTION
* Adds option to add video.js as a peerDependency and devDependency instead of a dependency, which should alleviate issues people have with installing plugins, espceially with yarn.
* Default behaviour is as current, as a dependency only.

To do:
- [ ] Should default to peer+dev instead